### PR TITLE
Make data fetch functions

### DIFF
--- a/libs/dataFetch.ts
+++ b/libs/dataFetch.ts
@@ -1,0 +1,71 @@
+import { client } from "./client";
+//import { Post,Tag } from "../types/postType";　一旦型は後回し
+
+////////////local function////////////
+
+function makeOrFilterQuery(itmes: string[]) {
+  //入ってきたtagNameの配列の各要素にtagName[equals]を追加し
+  //次の要素と[or]の文字列を挟んでjoinする処理
+  const query = itmes.map((item) => `tagName[equals]${item}`).join("[or]");
+
+  return query;
+}
+
+////////////global function////////////
+
+export async function getPostById(id: string) {
+  const data = await client.get({
+    endpoint: "posts",
+    contentId: id,
+  });
+
+  return data;
+}
+
+export async function getAllPosts() {
+  const data = await client.getAllContents({
+    endpoint: "posts",
+  });
+
+  return data;
+}
+
+export async function getAllTags() {
+  const data = await client.getAllContents({
+    endpoint: "tags",
+  });
+
+  return data;
+}
+
+export async function getTagsByTagName(tagNames: string[]) {
+  if (tagNames.length === 0) return "";
+
+  const tagNameQuery = makeOrFilterQuery(tagNames);
+
+  const data = await client.get({
+    endpoint: "tags",
+    queries: {
+      filters: tagNameQuery,
+    },
+  });
+
+  return data;
+}
+
+//export async function getPostsByTag(tagNames: string[]) {
+//  //tagNameが入ってきて、タグのIDを取得し、そのIDでPostsに連絡をかける
+//  const tags = getTagsByTagName(tagNames);
+//  const tagIdList = tags
+//    .then((res) => {
+//      return res.join();
+//    })
+//    .catch((e) => {
+//      console.log(e);
+//    });
+//
+//  await client.get({
+//    endpoint: "posts",
+//    //queries:{filters:}
+//  });
+//}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,52 @@
 import React from "react";
 import { Post, Tag } from "../../types/postType";
-import { getAllPosts, getAllTags } from "../../libs/dataFetch";
+import {
+  getAllPosts,
+  getAllTags,
+  getPostById,
+  getTagsByTagName,
+  getPostsByTagName,
+} from "../../libs/dataFetch";
 
 const Home: React.FC = async () => {
   const postData = await getAllPosts();
+  const idPost = await getPostById(postData[0].id);
   const tagData = await getAllTags();
+  const tagsData = await getTagsByTagName(["タグテスト1", "タグテスト3"]);
+  const postByTagName = await getPostsByTagName(["タグテスト1"]);
+
+  const emptyTagsData = await getTagsByTagName([]);
+  const emptyPostByTagName = await getPostsByTagName([]);
+
+  console.log(emptyPostByTagName);
+  console.log(emptyTagsData);
 
   return (
     <div>
       <main>
-        <h1>hoge</h1>
-        <h2>中タイトル</h2>
+        <h1 className="font-bold text-5xl">hoge</h1>
+        <h2 className="font-bold text-2xl">postとtag一覧</h2>
+        <h3 className="font-bold text-xl">post一覧</h3>
         {postData.map((post: Post) => {
-          return <p key={post.id}>{post.id}</p>;
+          return <p key={post.id}>{post.title}</p>;
         })}
+        <h3 className="font-bold text-xl">ポストをIDで呼び出す</h3>
+        <p>{idPost.title}</p>
+        <h3 className="font-bold text-xl">tagの名前一覧</h3>
         {tagData.map((tag: Tag) => {
-          return <p key={tag.tagName}>{tag.tagName}</p>;
+          return <p key={tag.id}>{tag.tagName}</p>;
+        })}
+        <h3 className="font-bold text-xl">
+          tagを任意の名前の配列で呼び出す(「タグテスト1」と「タグテスト3」)
+        </h3>
+        {tagsData.contents.map((tag: Tag) => {
+          return <p key={tag.id}>{tag.tagName}</p>;
+        })}
+        <h3 className="font-bold text-xl">
+          postを任意のtagの名前の配列で呼び出す(「タグテスト1」)
+        </h3>
+        {postByTagName.contents.map((post: Post) => {
+          return <p key={post.id}>{post.title}</p>;
         })}
       </main>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,21 @@
 import React from "react";
-import { client } from "../../libs/client";
-import { Post } from "@/type/postType";
+import { Post, Tag } from "../../types/postType";
+import { getAllPosts, getAllTags } from "../../libs/dataFetch";
 
 const Home: React.FC = async () => {
-  const postData = await client.get({ endpoint: "posts" });
-  //console.log(postData.contents);
+  const postData = await getAllPosts();
+  const tagData = await getAllTags();
 
   return (
     <div>
       <main>
         <h1>hoge</h1>
         <h2>中タイトル</h2>
-        {postData.contents.map((post: Post) => {
+        {postData.map((post: Post) => {
           return <p key={post.id}>{post.id}</p>;
+        })}
+        {tagData.map((tag: Tag) => {
+          return <p key={tag.tagName}>{tag.tagName}</p>;
         })}
       </main>
     </div>
@@ -20,5 +23,3 @@ const Home: React.FC = async () => {
 };
 
 export default Home;
-
-//<p>id:{postData.contents[0].id}</p>

--- a/types/postType.ts
+++ b/types/postType.ts
@@ -15,5 +15,5 @@ export type Tag = {
   updatedAt: string;
   publishedAt: string;
   revisedAt: string;
-  name: string;
+  tagName: string;
 };


### PR DESCRIPTION
## 概要
データ問い合わせ周りのロジックを作成した
- getPostById
- getAllPosts
- getAllTags
- getTagsByTagName
- getPostsByTagName
全体取得やID取得はオフィシャルから

## 学び
- microCMSは問い合わせ時にqueries:{ filters: "fieldID[logic]target" }のパラメーターを足すことでクエリをフィルタできる
- 上記は以下の形で呼び出し方に癖がある
  - 純粋なオブジェクトのリストの場合
    - queries:{ filters: "fieldID.element[logic]target" }と「.」で特定のパラメーターだけを呼び出すことができる
  - 参照コンテンツの場合
    - [公式リファレンス](https://help.microcms.io/ja/knowledge/contents-relation-search)によると、コンテンツIDのみでしか呼び出せない
      - 単数参照の場合
        - queries:{ filters: "fieldID[equals]targetID" }で呼び出す
      - 複数参照の場合
        - queries:{ filters: "fieldID[contains]targetID" }で呼び出す
  - 複雑な呼び出し（and,or）をやりたい場合
    - queries:{ filters: "fieldID[logic]target[or]fieldID[logic]target" }と[and]や[or]の後にそのままクエリを追加していく
- app routerではコンポーネントをasyncにして、その中で直接awaitで非同期呼び出しをしてデータを扱うことができる
  - つまり.then((res)=>{res.json()})の必要がない