### PR TITLE
READMEを書き換えてnodeのバージョンを記載した

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,11 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+## このリポジトリは何か
 
-## Getting Started
+2021 年~の作品をまとめたポートフォリオです。
 
-First, run the development server:
+## 使用技術
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Node.js : v20.18.0  
+Typescript : v5  
+React.js : v19.0.0  
+Next.js : v15.0.3  
+microCMS


### PR DESCRIPTION
## 概要
git clone→npm installで環境を合わせたがなぜかtsconfig.jsonにnodeの型が見つからないというエラーが出ていた。
ひとまず開発環境を合わせるべく、nodeのバージョンを合わせたところエラーは解決した。
nodeのバージョン違いによるエラーは不本意なので、READMEに使用技術を記載した。
README記載時に行末の空白を勝手に消してしまうエディタ側の動きを修正した。

## 学び
- nodeのバージョンが違うとあまり良くないので合わせながら作った方がいい
- markdownの改行のための行末空白がvscodeのデフォルトにある"files.trimTrailingWhitespace"というパラメータによって勝手に消されていた。
  - 上記をmarkdownに限りfalseにすることで解決した。