### PR TITLE
work/[slug]を作成。paramsでuriを拾えることを確認

### DIFF
--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const PostPage = async ({ params }: { params: Promise<{ slug: string }> }) => {
+  const uriString = (await params).slug;
+  console.log(uriString);
+
+  return (
+    <>
+      <main>
+        <p>postページだよ</p>
+        <p>{`${uriString}`}</p>
+      </main>
+    </>
+  );
+};
+
+export default PostPage;
+
+//メモ
+//propsには{ params : Promise<T> }の型の値が渡ってくる
+//Promiseの中身は{ dynamicRouteName : string }なので型は以下になる
+//{ params : Promise<{ dynamicRouteName : string }> }


### PR DESCRIPTION
## 概要
作品ページのための動的ルーティングを設定し、入力されたURIをparamsで拾ってくるところまでやった。
多分これでslugで記事を拾ってくるとかができるはず。

## 学び
- app routerでparamsを拾うためにはpageのコンポーネントをasyncにする（Promiseが渡ってくるため）
- 各pageのpropsに渡ってくるparamsの型は{ params : Promise\<T\> }である
  - Promiseの中身として渡ってくる値は、フォルダ名として指定したdynamicRouteNameをkeyに持つ、{ dynamicRouteName : string }である
    - 例
      - フォルダ名[slug]
      - /[slug]の設定
      - /hogeにアクセス → 返り値：{ slug : "アクセスされてるURI" }
  - 結果paramsの型はこうなる→{ params : Promise<{ dynamicRouteName : string }> }
- 最終的にparamsを利用するページのコードは以下

```
const hoge = async ( { params } : { params : Promise<{ dynamicRouteName : string }> } ) => {
  const dynamicRouteNameValue = ( await params ).dynamicRouteName
  
  return (
    <>
      <p>{`${ dynamicRouteNameValue }`}</p>
    </>
   )
```

- (await hoge).fugaっていう呼び出し方を知った
  - awaitでPromise本体を解きつつ中身のjsonの各keyにアクセスできる
  - まぁ一回解いて定数にした方が他でも呼びやすいから滅多に使わない方法だけど

## 参考
[Next.jsのDynamic Routesのドキュメント](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes)