### PR TITLE
paramsの型が見づらいので整理

### DIFF
--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-const PostPage = async ({ params }: { params: Promise<{ slug: string }> }) => {
+type returnParamsValueType = { slug: string };
+type paramsType<T> = { params: Promise<T> };
+
+const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
   const uriString = (await params).slug;
   console.log(uriString);
 


### PR DESCRIPTION
## 概要
[slug]ディレクトリのpage.tsxのparamsにつけていた型が見づらかったので整理した。

## 学び
- propsを分割代入する時の見た目にさらにオブジェクトの型をつける時は結構見づらい
- オブジェクトの型の中にPromise\<T\>があり、そのTにさらにオブジェクトの型を入れるという複雑な入れ子
- それぞれ1つずつ処理するように変更しpropsの引数部分で型が並ぶようにした（型を追いかける労力を減らすため）