### PR TITLE
generateStaticParamsを動的ルーティング対象に追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,11 +15,11 @@ const Home: React.FC = async () => {
   const tagsData = await getTagsByTagName(["タグテスト1", "タグテスト3"]);
   const postByTagName = await getPostsByTagName(["タグテスト1"]);
 
-  const emptyTagsData = await getTagsByTagName([]);
-  const emptyPostByTagName = await getPostsByTagName([]);
+  //const emptyTagsData = await getTagsByTagName([]);
+  //const emptyPostByTagName = await getPostsByTagName([]);
 
-  console.log(emptyPostByTagName);
-  console.log(emptyTagsData);
+  //console.log(emptyPostByTagName);
+  //console.log(emptyTagsData);
 
   return (
     <div>

--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import React from "react";
+import { getAllPosts } from "../../../../libs/dataFetch";
 
 type returnParamsValueType = { slug: string };
 type paramsType<T> = { params: Promise<T> };
 
 const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
-  const uriString = (await params).slug;
+  const uriString = await params;
   console.log(uriString);
 
   return (
@@ -19,7 +20,11 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
 
 export default PostPage;
 
-//メモ
-//propsには{ params : Promise<T> }の型の値が渡ってくる
-//Promiseの中身は{ dynamicRouteName : string }なので型は以下になる
-//{ params : Promise<{ dynamicRouteName : string }> }
+export async function generateStaticParams() {
+  const posts = await getAllPosts();
+  const postURIs = posts.map((post) => {
+    return { slug: post.postUri };
+  });
+
+  return postURIs;
+}


### PR DESCRIPTION
## 概要
app routerになったNextにて静的ドキュメントの生成に必要な関数（generateStaticParams）を実装した。
build時にこの関数がreturnするオブジェクトを元に静的ドキュメントを生成する。

## 学び
- 静的ドキュメントの生成（SSG）にはgenerateStaticParamsの実装が必要
- 上記の関数で以下のオブジェクトのリストをreturnするとNextはbuild時にこのオブジェクトを元にドキュメントを生成する。
  - `{ 動的ルーティングの名前に使用した文字列: 生成したいuri }`

■以下具体例
**ディレクトリ構造**
```
app
┗ works
　┗ [ slug ]
　　┗ page.tsx
```

**上記のディレクトリ構造におけるgenerateStaticParams**
```
export async function generateStaticParams() {
  const posts = await getAllPosts(); // 記事のuriのfetch
  const postURIs = posts.map((post) => {
    return { slug: post.postUri }; 
  });

  return postURIs; // { dynamicRouteName: uri }のオブジェクトのリストをreturn
}
```

おそらく手打ちで
```
[  { slug: "hoge" }, { slug: "fuga" }, { slug: "piyo" }]
```
とかを直接returnしても原理上動くと思われる。

なおこの関数を動かすためには
```
npm run build
```
をしないといけない。
この時envファイルが
```
.env.development.local
```
のように
```
.development
```
を含んでいると、開発環境でしか. envファイルを呼び出せないためビルドに失敗する。
なので、buildする時は.envファイルから開発環境での使用の部分を削除する。