### PR TITLE
worksページのレイアウト完成

### DIFF
--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -9,22 +9,28 @@ const WorksPage: React.FC = () => {
   return (
     <>
       <main>
-        <div>
-          <Image
-            src={"/works-title.png"}
-            alt="#"
-            width={448}
-            height={112}
-          ></Image>
+        <div className="flex">
+          <div className="-mb-28 p-10 w-full h-96 bg-gray-300 border-b-2 border-r-2 border-black rounded-br-3xl">
+            <div className="mb-6">
+              <Image
+                src={"/works-title.png"}
+                alt="#"
+                width={448}
+                height={112}
+              ></Image>
+            </div>
+            <div className="flex gap-6">
+              <span>フィルタ</span>
+              <Tag id="1" tagName="Product" size="large"></Tag>
+              <Tag id="2" tagName="Project" size="large"></Tag>
+              <Tag id="3" tagName="WorkShop" size="large"></Tag>
+            </div>
+          </div>
+          <div className="p-10">
+            <Header />
+          </div>
         </div>
-        <Header />
-        <div className="flex gap-6">
-          <span>フィルタ</span>
-          <Tag id="1" tagName="Product"></Tag>
-          <Tag id="2" tagName="Project"></Tag>
-          <Tag id="3" tagName="WorkShop"></Tag>
-        </div>
-        <div className="flex gap-12 flex-wrap">
+        <div className="px-10 pb-10 flex gap-12 flex-wrap">
           <Card id="1" title="カード1"></Card>
           <Card id="2" title="カード2"></Card>
           <Card id="3" title="カード3"></Card>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,10 +1,7 @@
 import React from "react";
 import { TagType } from "../../types/postType";
 
-type OmitTagType = Omit<
-  TagType,
-  "createdAt" | "updatedAt" | "publishedAt" | "revisedAt"
->;
+type OmitTagType = Pick<TagType, "id" | "tagName">;
 type CommponentTagType = OmitTagType & {
   size?: "small" | "medium" | "large";
 };

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { TagType } from "../../types/postType";
 
-type OmitTagType = Pick<TagType, "id" | "tagName">;
-type CommponentTagType = OmitTagType & {
+type PickTagType = Pick<TagType, "id" | "tagName">;
+type CommponentTagType = PickTagType & {
   size?: "small" | "medium" | "large";
 };
 

--- a/types/postType.ts
+++ b/types/postType.ts
@@ -1,19 +1,27 @@
-export type PostType = {
+type MicroCmsApiReturnType = {
   id: string;
   createdAt: string;
   updatedAt: string;
   publishedAt: string;
   revisedAt: string;
-  title: string;
-  tags: TagType[];
-  description: HTMLElement;
 };
 
-export type TagType = {
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-  publishedAt: string;
-  revisedAt: string;
+type MicroCmsImageType = {
+  url: string;
+  height: number;
+  width: number;
+};
+
+export type PostType = MicroCmsApiReturnType & {
+  title: string;
+  postUri: string;
+  postImage?: MicroCmsImageType;
+  tags?: TagType[];
+  description?: HTMLElement;
+  carouselImage?: MicroCmsImageType;
+  carouselDescription?: string;
+};
+
+export type TagType = MicroCmsApiReturnType & {
   tagName: string;
 };


### PR DESCRIPTION
## 概要
worksページのレイアウトを作成した
次はTagとCardをもう少しデザインに正確に改善する

## 学び
- 交差型は素のままだと組み合わせた型の中身が見えない
- 交差型の展開拡張機能があることを知った（Prettify TypeScript）
- 型がめちゃくちゃ大きくなってくると必須と任意をRequire<T>とPersial<T>で分けて交差型で繋ぐといいらしい。
  - [サバイバルTypescript](https://typescriptbook.jp/reference/values-types-variables/intersection)

今回は型が拡大したので見やすくできるように重複部分を切り出して交差型にした。