### PR TITLE
フェッチしたデータを画面に表示することに成功した

### DIFF
--- a/libs/dataFetch.ts
+++ b/libs/dataFetch.ts
@@ -1,6 +1,6 @@
 import { client } from "./client";
 //import { Post,Tag } from "../types/postType";　一旦型は後回し
-import { Tag } from "../types/postType";
+import { TagType } from "../types/postType";
 
 ////////////local type////////////
 
@@ -80,7 +80,7 @@ export async function getPostsByTagName(tagNames: string[]) {
   if (tagNames.length === 0) return "tagNames is empty";
 
   const tags = await getTagsByTagName(tagNames);
-  const tagIds: string[] = tags.contents.map((tag: Tag) => {
+  const tagIds: string[] = tags.contents.map((tag: TagType) => {
     return tag.id;
   });
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,16 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.microcms-assets.io",
+        port: "",
+        pathname: "/assets/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,13 @@ import Image from "next/image";
 import Link from "next/link";
 import Header from "../components/Header";
 
+import { getAllPosts } from "../../libs/dataFetch";
+
 const Home: React.FC = async () => {
+  const posts = await getAllPosts();
+
+  console.log(posts);
+
   return (
     <>
       <main className="h-full">
@@ -18,26 +24,47 @@ const Home: React.FC = async () => {
                 className="bg-blue-800"
               ></Image>
             </div>
-            <div className="h-full w-full bg-blue-800 rounded-3xl border-2 border-black flex ">
-              <div className="px-10 py-6 flex flex-col">
-                <div className="h-full w-80 flex flex-col items-center flex-grow">
-                  <h2 className="text-2xl text-white">タイトル</h2>
-                  <p className="text-sm text-white">プロジェクト期間</p>
-                  <p className="text-base text-white">
-                    文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章文章
-                  </p>
-                </div>
-                <Link
-                  href={"/#"}
-                  className="w-full h-10 px-4 py-2 bg-black text-white text-sm rounded-full"
+
+            {posts.map((post) => {
+              return (
+                <div
+                  key={post.id}
+                  className="h-full w-full bg-blue-800 rounded-3xl border-2 border-black flex "
                 >
-                  プロダクトへ
-                </Link>
-              </div>
-              <div>
-                <Image src={"/#"} width={800} height={600} alt="hoge"></Image>
-              </div>
-            </div>
+                  <div className="px-10 py-6 flex flex-col">
+                    <div className="h-full w-80 flex flex-col items-center flex-grow">
+                      <h2 className="text-2xl text-white">{post.title}</h2>
+                      <p className="text-sm text-white">
+                        {post.projectPeriod
+                          ? post.projectPeriod
+                          : "ダミー期間だよ"}
+                      </p>
+                      <p className="text-base text-white">
+                        {post.carouselDescription
+                          ? post.carouselDescription
+                          : "ダミー文ですよ"}
+                      </p>
+                    </div>
+                    <Link
+                      href={"/#"}
+                      className="w-full h-10 px-4 py-2 bg-black text-white text-sm rounded-full"
+                    >
+                      プロダクトへ
+                    </Link>
+                  </div>
+                  <div>
+                    <Image
+                      src={
+                        post.carouselImage?.url ? post.carouselImage?.url : "/#"
+                      }
+                      alt="hoge"
+                      width={512}
+                      height={512}
+                    />
+                  </div>
+                </div>
+              );
+            })}
           </div>
           <div className="pt-6 pb-8 px-4 h-full flex flex-col gap-12">
             <Header />


### PR DESCRIPTION
## 概要
microCMSからGetしたデータ群を画面にmapで出し切ることに成功した

## 学び
Next js v14からNext Imageコンポーネントのsrcプロパティに外部のURLを入れる方法が変わった。
以下の設定をnext.config.tsに設定しないと外部からの画像URLを代入できない。
```typescript
import type { NextConfig } from "next";

const nextConfig: NextConfig = {
  /* ここからポイント！！ */
  images: {
    remotePatterns: [
      {
        protocol: "https", //httpかhttps
        hostname: "example.com", //画像URLのホスト部分
        port: "",
        pathname: "/assets/**", //画像URLのパス部分
      },
    ],
  },
};

export default nextConfig;

```

[remotePatternsの公式ドキュメント](https://nextjs.org/docs/pages/api-reference/components/image#remotepatterns)
ここの設定を間違えていると、ご丁寧にエラー文で`「https//hoge.com/fuga/[id]を代入できないよ」`と言われるので、ここに出ているURLをベースに上記の設定を埋めればURL設定がうまくいく。
ワイルドカードが使えて
```
pathname: "/assets/**", 
```
ここは`assets以下のすべてのもの`の意味。

imageがなかった時にimage.urlにアクセスできないので
```
<Image
  src={
    post.carouselImage?.url ? post.carouselImage.url : "/#"
  }
  alt="#"
  width={512}
  height={512}
/>
```
のように
`post.carouselImage?.url ? post.carouselImage.url : "/#"`
ここで[オプショナルチェーン](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Optional_chaining)と三項演算を使って確実に画像が出るようにした。
"/#"部分をfallback画像にすれば完成。