### PR TITLE
とりあえずカルーセルとHomeページのつなぎこみとスタイルを修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import Header from "../components/Header";
+import HomePostCard from "../components/HomePostCard";
 
 import { getAllPosts } from "../../libs/dataFetch";
 
@@ -12,55 +13,29 @@ const Home: React.FC = async () => {
     <>
       <main className="h-full">
         <div className="flex h-full">
-          <div className="w-full h-full py-8 px-6 flex flex-col gap-4 bg-blue-200">
-            <div className="h-32 w-full flex justify-center">
+          <div className="w-full h-full py-8 px-6 bg-blue-200 flex flex-col items-center gap-4">
+            <div className="w-full bg-blue-800">
               <Image
                 src="/main-logo.png"
                 width={980}
                 height={138}
                 alt="Picture of the author"
-                className="bg-blue-800"
+                className="m-auto"
               ></Image>
             </div>
 
             {posts.map((post) => {
+              console.log(post.carouselImage.url);
               return (
-                <div
-                  key={post.id}
-                  className="h-full w-full bg-blue-800 rounded-3xl border-2 border-black flex "
-                >
-                  <div className="px-10 py-6 flex flex-col">
-                    <div className="h-full w-80 flex flex-col items-center flex-grow">
-                      <h2 className="text-2xl text-white">{post.title}</h2>
-                      <p className="text-sm text-white">
-                        {post.projectPeriod
-                          ? post.projectPeriod
-                          : "ダミー期間だよ"}
-                      </p>
-                      <p className="text-base text-white">
-                        {post.carouselDescription
-                          ? post.carouselDescription
-                          : "ダミー文ですよ"}
-                      </p>
-                    </div>
-                    <Link
-                      href={`/works/${post.postUri}`}
-                      className="w-full h-10 px-4 py-2 bg-black text-white text-sm rounded-full"
-                    >
-                      プロダクトへ
-                    </Link>
-                  </div>
-                  <div>
-                    <Image
-                      src={
-                        post.carouselImage?.url ? post.carouselImage.url : "/#"
-                      }
-                      alt="hoge"
-                      width={512}
-                      height={512}
-                    />
-                  </div>
-                </div>
+                <HomePostCard
+                  id={post.id}
+                  title={post.title}
+                  projectPeriod={post.projectPeriod}
+                  tags={post.tags}
+                  carouselDescription={post.carouselDescription}
+                  carouselImageUrl={post.carouselImage.url}
+                  postUri={post.postUri}
+                />
               );
             })}
           </div>

--- a/src/components/HomePostCard.tsx
+++ b/src/components/HomePostCard.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import Link from "next/link";
+import { MicroCmsImageType, TagType } from "../../types/postType";
+import Image from "next/image";
+import Tag from "../components/Tag";
+
+type HomePostCardType = {
+  id: string;
+  title: string;
+  projectPeriod?: string;
+  tags?: TagType[];
+  carouselDescription?: string;
+  carouselImageUrl?: string;
+  postUri: string;
+};
+
+const HomePostCard: React.FC<HomePostCardType> = (props) => {
+  return (
+    <div
+      key={props.id}
+      className="h-full w-full bg-blue-800 rounded-3xl border-2 border-black flex "
+    >
+      <div className="w-1/3 px-10 py-16 flex flex-col">
+        <div className="h-full flex-grow">
+          <h2 className="text-2xl font-bold text-white">{props.title}</h2>
+          <p className="mb-2 text-sm text-white">
+            {props.projectPeriod ? props.projectPeriod : "ダミー期間だよ"}
+          </p>
+          <div className="mb-8">
+            {props.tags?.map((tag) => {
+              return (
+                <Tag key={tag.id} id={tag.id} tagName={`${tag.tagName}`} />
+              );
+            })}
+          </div>
+          <p className="text-xs font-bold leading-relaxed text-white">
+            {props.carouselDescription
+              ? props.carouselDescription
+              : "ダミー文ですよ"}
+          </p>
+        </div>
+        <Link
+          href={`/works/${props.postUri}`}
+          className="w-full h-10 px-4 py-2 bg-black text-white text-center text-sm font-bold rounded-full"
+        >
+          プロダクトへ
+        </Link>
+      </div>
+      <div className="w-2/3 relative">
+        <Image
+          src={props.carouselImageUrl ? props.carouselImageUrl : "/my-icon"}
+          alt="hoge"
+          fill
+        />
+      </div>
+    </div>
+  );
+};
+
+export default HomePostCard;

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -13,7 +13,7 @@ const Card: React.FC<CommponentTagType> = ({ size = "small", ...args }) => {
 
   return (
     <div
-      className={`px-2 font-bold rounded-full border border-black ${
+      className={`px-2 font-bold rounded-full bg-white border border-black ${
         size == "small"
           ? smallStyle
           : size == "medium"

--- a/types/postType.ts
+++ b/types/postType.ts
@@ -6,7 +6,7 @@ type MicroCmsApiReturnType = {
   revisedAt: string;
 };
 
-type MicroCmsImageType = {
+export type MicroCmsImageType = {
   url: string;
   height: number;
   width: number;


### PR DESCRIPTION
## 概要
ホームページのカルーセルカードをコンポーネントにし、独立させた。
スタイルも整理し、綺麗にした。
ただ、幅1440pxをmaxにする処理が今後必要
1280~1440で今の見た目をコントロールし、1280を下回った場合は別の画面にしていく

## 学び
Next Imageのfillプロパティは以下のCSSがあたってくる
```css
position: absolute;
width: 100%;
height: 100%;
top: 0;
bottom: 0;
left: 0;
right 0;
```
なので周りをdivで囲んで、
```css
position: rerative
```
を入れるとdivの大きさになってくれる