### PR TITLE
styleシート作ったり色々直した

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,10 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+import { Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 
-const geistSans = localFont({
-  src: "./fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "./fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
+const NotoSansJP = Noto_Sans_JP({
+  subsets: ["latin"],
+  variable: "--font-noto-sans-jp",
 });
 
 export const metadata: Metadata = {
@@ -24,10 +18,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased h-svh`}
-      >
+    <html lang="ja">
+      <body className={`${NotoSansJP.variable} font-noto-sans-jp h-svh`}>
         {children}
       </body>
     </html>

--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -8,6 +8,8 @@ import Footer from "../../../components/Footer";
 import Tag from "../../../components/Tag";
 import { TagType } from "../../../../types/postType";
 
+import "../../../../styles/postStyle.css";
+
 type returnParamsValueType = { slug: string };
 type paramsType<T> = { params: Promise<T> };
 type TargetTagType = { tagName: string; tagId: string };
@@ -33,7 +35,7 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
               <span> &gt; </span>
               <span>{`${postContents.title}`}</span>
             </div>
-            <div className="flex items-center">
+            <div className="flex items-center gap-4">
               <h1 className="text-4xl font-bold flex-grow">{`${postContents.title}`}</h1>
               <p>プロジェクト期間：{`${postContents.projectPeriod}`}</p>
               {targetTagObjects.map((tag: TargetTagType) => {
@@ -54,28 +56,37 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
                   : "/test.png"
               }`}
               alt="#"
-              width={920}
-              height={460}
-              className="bg-gray-300 rounded-3xl"
+              width={960}
+              height={480}
+              className="bg-gray-300 rounded-3xl border-2 border-black"
             />
-            <div>
-              <div
-                dangerouslySetInnerHTML={{ __html: postContents.description }}
-              ></div>
-            </div>
+            <div
+              className="post-discription"
+              dangerouslySetInnerHTML={{ __html: postContents.description }}
+            ></div>
           </div>
           <div className="flex flex-col items-center gap-10">
             <Header />
             <div className="flex flex-col gap-4">
-              {sideCardPosts.map((post) => {
-                return (
-                  <Card
-                    key={`${post.id}`}
-                    id={`${post.id}`}
-                    title={`${post.title}`}
-                  />
-                );
-              })}
+              {sideCardPosts
+                .filter((post) => {
+                  return post.postUri !== uriString.slug;
+                })
+                .map((post) => {
+                  console.log(post.carouselImage);
+                  return (
+                    <Link href={`/works/${post.postUri}`} key={`${post.id}`}>
+                      <Card
+                        id={`${post.id}`}
+                        title={`${post.title}`}
+                        imageUrl={`${
+                          post.carouselImage ? post.carouselImage.url : ""
+                        }`}
+                        description=" "
+                      />
+                    </Link>
+                  );
+                })}
             </div>
           </div>
         </div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -39,7 +39,7 @@ const Card: React.FC<CardType> = (props) => {
           );
         })}
       </div>
-      <p className="text-sm font-semibold leading-7">
+      <p className="text-sm font-medium leading-7">
         {props.description ? `${props.description}` : dummyDescription}
       </p>
     </div>

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -73,7 +73,7 @@ const Carousel: React.FC<CarouselType> = (props) => {
                 projectPeriod={slide.projectPeriod}
                 tags={slide.tags}
                 carouselDescription={slide.carouselDescription}
-                carouselImageUrl={slide.carouselImage.url}
+                carouselImageUrl={slide.carouselImage?.url}
                 postUri={slide.postUri}
               />
             </SwiperSlide>

--- a/styles/postStyle.css
+++ b/styles/postStyle.css
@@ -1,0 +1,71 @@
+.post-discription {
+  h2:first-child {
+    margin-top: 0;
+  }
+
+  h2 {
+    margin-top: 4rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 150%;
+    border-bottom: solid 1px gray;
+  }
+
+  h3 {
+    margin-top: 2.5rem;
+    margin-bottom: 1.25rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 150%;
+  }
+
+  p {
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 200%;
+  }
+
+  ul {
+    margin: 1rem 0;
+    list-style: disc;
+    list-style-position: inside;
+    line-height: 175%;
+  }
+
+  li {
+    ul {
+      list-style: circle;
+      list-style-position: inside;
+      padding-left: 1.5rem;
+      margin: 0;
+    }
+  }
+
+  ol {
+    margin: 1rem 0;
+    list-style: decimal;
+    list-style-position: inside;
+    line-height: 175%;
+  }
+
+  code {
+    display: block;
+    margin: 2.5rem 0;
+    padding: 2.5rem;
+    border-radius: 1rem;
+    background-color: #f1f2f4;
+    border: solid 2px black;
+  }
+
+  figure {
+    margin: 1rem 0;
+  }
+
+  img {
+    margin: auto;
+    border-radius: 1rem;
+    border: solid 1px gray;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,9 @@ export default {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    fontFamily: {
+      "noto-sans-jp": ["var(--font-noto-sans-jp)", "sans-serif"],
+    },
     extend: {
       colors: {
         background: "var(--background)",


### PR DESCRIPTION
## 概要
記事詳細用のスタイルシートを作って、Noto Sans JPを全体に当てた

## 学び

### google font の登録
Noto sans jpを使用するためnext/font/googleを使用する。
next/fontは以下の形で設定する。

`layout.tsx`
```typescript
import { font名 } from "next/font/google"

const NotoSansJP = font名(
  {
    subset: ["latin"]
    variable: "任意のcss変数名"
  }
)

export default function RootLayout({
  children,
}: Readonly<{
  children: React.ReactNode;
}>) {
  return (
    <html lang="ja">
      <body className={`${NotoSansJP.variable} tailwindで登録したクラス名`}>　//${NotoSansJP.variable}で上記で設定したcss変数を宣言。これがないと登録したcss変数が使えない
        {children}
      </body>
    </html>
  );
}
```
これだけではダメで、tailwind.config.jsの編集との合わせ技が必要。
next/fontはあくまで「取得したフォントが有効になるためのcss変数の用意」だけを担当する。
スタイルを当てるにはtailwind.config.jsに有効にしたcss変数を登録し、オリジナルで作ったclassNameを当てる必要がある。


`tailwind.config.js`
```javascript
import type { Config } from "tailwindcss";

export default {
  content: [
    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
  ],
  theme: {
    fontFamily: { //ここでフォントファミリーを設定
      "noto-sans-jp": ["var(--font-noto-sans-jp)", "sans-serif"], // font-noto-sans-jpで呼べるようになる
    },
    extend: {
      colors: {
        background: "var(--background)",
        foreground: "var(--foreground)",
      },
    },
  },
  plugins: [],
} satisfies Config;
```
これでclassName="font-noto-sans-jp"でNoto sansを当てられるようになった。
これをbodyタグなりhtmlタグに当てて全てNoto sansの支配下にするとOK。

### 参考
[googleフォント×tailwindの記事](https://imakyo.net/blog/next-font-apply)