### PR TITLE
tailwindのカラーパレットを作り、スペースを拡張

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={`${NotoSansJP.variable} font-noto-sans-jp h-svh`}>
+      <body
+        className={`${NotoSansJP.variable} text-gray-900 text-red font-noto-sans-jp h-svh`}
+      >
         {children}
       </body>
     </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,10 +10,46 @@ export default {
     fontFamily: {
       "noto-sans-jp": ["var(--font-noto-sans-jp)", "sans-serif"],
     },
+    colors: {
+      white: {
+        0: "#FFFFFF",
+      },
+      gray: {
+        100: "#F1F2F4",
+        300: "#E3E5E8",
+        500: "#949DAD",
+        900: "#232323",
+      },
+      red: {
+        600: "#FA5A2E",
+        700: "#E23F12",
+      },
+      blue: {
+        500: "#0073E5",
+        600: "#1466B8",
+        700: "#115497",
+      },
+      green: {
+        600: "#09A974",
+        700: "#089164",
+      },
+      yellow: {
+        600: "#F9A806",
+        700: "#F49106",
+      },
+      pink: {
+        600: "#FF7E7E",
+      },
+    },
     extend: {
       colors: {
         background: "var(--background)",
         foreground: "var(--foreground)",
+      },
+      spacing: {
+        18: "4.5rem",
+        22: "5.5rem",
+        30: "7.5rem",
       },
     },
   },


### PR DESCRIPTION
## 概要
tailwind configをカスタムして独自カラーパレットを作り、spaceを拡張した

## 学び
割と簡単にtailwind configでtailwindはカスタムできた
extend内でカスタムを行うか、extendの外でカスタムするかで挙動が変わる。
extend内ならデフォルトの設定を消さずに設定を上書きする。そのため、設定していないところもデフォルト設定が効く。
extendの外の場合はデフォルト設定を全て捨てて、作ったものだけしか使えない状態にする。
色に関してはextendの外の方が良さそう。

```JavaScript
import type { Config } from "tailwindcss";

export default {
  content: [
    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
  ],
  theme: {
    fontFamily: {
      "noto-sans-jp": ["var(--font-noto-sans-jp)", "sans-serif"],
    },
    //extend外なので拡張ではなく書き換え
    colors: {
      white: {
        0: "#FFFFFF",
      },
      gray: {
        100: "#F1F2F4",
        300: "#E3E5E8",
        500: "#949DAD",
        900: "#232323",
      },
      red: {
        600: "#FA5A2E",
        700: "#E23F12",
      },
      blue: {
        500: "#0073E5",
        600: "#1466B8",
        700: "#115497",
      },
      green: {
        600: "#09A974",
        700: "#089164",
      },
      yellow: {
        600: "#F9A806",
        700: "#F49106",
      },
      pink: {
        600: "#FF7E7E",
      },
    },
    extend: {
      colors: {
        background: "var(--background)",
        foreground: "var(--foreground)",
      },
      //extend内なので上書き
      spacing: {
        18: "4.5rem",
        22: "5.5rem",
        30: "7.5rem",
      },
    },
  },
  plugins: [],
} satisfies Config;

```