### PR TITLE
colorの置き換えと記事詳細のCSSの作り込み

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,7 +7,7 @@ const AboutPage: React.FC = () => {
   return (
     <main className="h-svh flex flex-col">
       <div className="flex -mb-24">
-        <div className="w-full p-10 rounded-br-3xl border-r-2 border-b-2 border-black bg-gray-300">
+        <div className="w-full p-10 rounded-br-3xl border-r-2 border-b-2 border-gray-900 bg-gray-300">
           <h1>
             <Image
               src={"/about-title.png"}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,8 +14,8 @@ const Home: React.FC = async () => {
     <>
       <main className="h-full">
         <div className="flex h-full">
-          <div className="w-full h-full py-8 px-6 bg-blue-200 flex flex-col items-center gap-4">
-            <div className="w-full bg-blue-800">
+          <div className="w-full h-full py-8 px-6 bg-blue-600 flex flex-col items-center gap-4">
+            <div className="w-full bg-blue-700">
               <Image
                 src="/main-logo.png"
                 width={980}

--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -28,7 +28,7 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
       <main>
         <div className="p-10 flex gap-10">
           <div className="w-full flex flex-col gap-6">
-            <div className="px-4 h-10 border-2 border-black rounded-full leading-10">
+            <div className="px-4 h-10 border-2 border-gray-900 rounded-full leading-10">
               <Link href={"/"}>Home</Link>
               <span> &gt; </span>
               <Link href={"/works"}>Works</Link>
@@ -58,7 +58,7 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
               alt="#"
               width={960}
               height={480}
-              className="bg-gray-300 rounded-3xl border-2 border-black"
+              className="bg-gray-300 rounded-3xl border-2 border-gray-900"
             />
             <div
               className="post-discription"

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -17,7 +17,7 @@ const WorksPage: React.FC = async () => {
     <>
       <main>
         <div className="-mb-20 flex">
-          <div className="p-10 w-full h-80 bg-gray-300 border-b-2 border-r-2 border-black rounded-br-3xl">
+          <div className="p-10 w-full h-80 bg-gray-300 border-b-2 border-r-2 border-gray-900 rounded-br-3xl">
             <div className="mb-6">
               <Image
                 src={"/works-title.png"}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -22,7 +22,7 @@ const Card: React.FC<CardType> = (props) => {
         alt=""
         width={640}
         height={320}
-        className="rounded-3xl border-2 border-black mb-2"
+        className="rounded-3xl border-2 border-gray-900 mb-2"
       />
       <div className="mb-2">
         <div className="mb-2">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 const Footer: React.FC = () => {
   return (
-    <footer className="px-20 py-10 flex gap-20 border-t-2 border-black bg-gray-100">
+    <footer className="px-20 py-10 flex gap-20 border-t-2 border-gray-900 bg-gray-100">
       <div>
         <h3 className="font-bold text-lg">サイトマップ</h3>
         <div className="pt-6 flex flex-col gap-3">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,14 +3,14 @@ import Link from "next/link";
 
 const Header: React.FC = () => {
   return (
-    <header className="h-40 w-40 bg-black rounded-full flex flex-col justify-center items-center">
-      <nav className="text-white">
+    <header className="h-40 w-40 bg-gray-900 text-white-0 rounded-full flex flex-col justify-center items-center">
+      <nav>
         <Link href={"/"}>Home</Link>
       </nav>
-      <nav className="text-white">
+      <nav>
         <Link href={"/works"}>Works</Link>
       </nav>
-      <nav className="text-white">
+      <nav>
         <Link href={"/about"}>About</Link>
       </nav>
     </header>

--- a/src/components/HomePostCard.tsx
+++ b/src/components/HomePostCard.tsx
@@ -18,9 +18,9 @@ const HomePostCard: React.FC<HomePostCardType> = (props) => {
   return (
     <div
       key={props.id}
-      className="h-full w-full bg-blue-800 rounded-3xl border-2 border-black flex items-center overflow-hidden"
+      className="h-full w-full bg-blue-700 rounded-3xl border-2 border-gray-900 flex items-center overflow-hidden"
     >
-      <div className="h-full w-1/3 px-10 py-16 flex flex-col">
+      <div className="h-full w-1/3 px-10 py-16 flex flex-col text-white-0">
         <div className="h-full flex-grow">
           <h2 className="text-2xl font-bold text-white">{props.title}</h2>
           <p className="mb-2 text-sm text-white">
@@ -35,7 +35,7 @@ const HomePostCard: React.FC<HomePostCardType> = (props) => {
               );
             })}
           </div>
-          <p className="text-s font-bold leading-relaxed text-white">
+          <p className="text-sm font-medium leading-relaxed text-white">
             {props.carouselDescription
               ? props.carouselDescription
               : "ダミー文ですよ"}
@@ -43,7 +43,7 @@ const HomePostCard: React.FC<HomePostCardType> = (props) => {
         </div>
         <Link
           href={`/works/${props.postUri}`}
-          className="w-full h-10 px-4 py-2 bg-black text-white text-center text-sm font-bold rounded-full"
+          className="w-full h-10 px-4 py-2 bg-gray-900 text-white-0 text-center text-sm font-bold rounded-full"
         >
           プロダクトへ
         </Link>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -13,7 +13,7 @@ const Card: React.FC<CommponentTagType> = ({ size = "small", ...args }) => {
 
   return (
     <div
-      className={`px-2 font-bold rounded-full bg-white border border-black ${
+      className={`px-2 font-bold rounded-full bg-white-0 text-gray-900 border border-gray-900 ${
         size == "small"
           ? smallStyle
           : size == "medium"

--- a/styles/postStyle.css
+++ b/styles/postStyle.css
@@ -10,7 +10,7 @@
     font-size: 1.5rem;
     font-weight: 700;
     line-height: 150%;
-    border-bottom: solid 1px gray;
+    border-bottom: solid 1px #949dad;
   }
 
   h3 {
@@ -56,7 +56,27 @@
     padding: 2.5rem;
     border-radius: 1rem;
     background-color: #f1f2f4;
-    border: solid 2px black;
+    border: solid 2px #232323;
+  }
+
+  div:has(code) {
+    position: relative;
+  }
+
+  div:has(code)::before {
+    content: attr(data-filename);
+    position: absolute;
+    top: 0.25rem;
+    left: 0.25rem;
+    display: inline-block;
+    background-color: #232323;
+    color: #ffffff;
+    border-radius: 9999px;
+    height: 1.5rem;
+    padding: 0 0.5rem;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.5rem;
   }
 
   figure {
@@ -66,6 +86,56 @@
   img {
     margin: auto;
     border-radius: 1rem;
-    border: solid 1px gray;
+    border: solid 1px #e3e5e8;
+  }
+
+  table {
+    width: 100%;
+    margin: 1rem 0;
+    overflow: hidden;
+    table-layout: fixed;
+    border-radius: 1rem;
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  tr:last-child > td:last-child {
+    border-radius: 0 0 1rem 0;
+  }
+
+  tr:last-child > td:first-child {
+    border-radius: 0 0 0 1rem;
+  }
+
+  th {
+    height: 2rem;
+    padding: 0 0.5rem;
+    border-right: solid 1px #e3e5e8;
+    background-color: #f1f2f4;
+  }
+
+  th p {
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  th:last-child {
+    border-right: none;
+  }
+
+  td {
+    padding: 0.5rem;
+    border-bottom: solid 1px #e3e5e8;
+    border-right: solid 1px #e3e5e8;
+  }
+
+  td p,
+  td li {
+    font-size: 14px;
+    line-height: 150%;
+  }
+
+  td:first-child {
+    border-left: solid 1px #e3e5e8;
   }
 }


### PR DESCRIPTION
## 概要

## 学び
### CSSの:hasクラス
このようなhtmlがある時に
```html
<div>
  <p>ほげ</p>
</div>
<div>
  <span>ふが</span>
</div>
```
このようなCSSを書くと
```css
div:has(span){
  background-color: black;
}
```
spanタグを持っているdivの背景だけ黒くなる

ちなみに
```css
div:has(.hoge-class){
  background-color: black;
}
```
のようにクラスを指定することもできる

### 参考
[:has :is :whereの違いの記事](https://gihyo.jp/article/2024/10/ride-modern-frontend-01)
[コリス](https://coliss.com/articles/build-websites/operation/css/has-pseudo-class.html)