### PR TITLE
なんとかコードブロックの横スクロールに成功

### DIFF
--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -26,9 +26,9 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
   return (
     <>
       <main>
-        <div className="px-10 pt-10 pb-20  flex justify-center">
-          <div className="flex gap-10 max-w-[1200px]">
-            <div className="w-full flex flex-col gap-6">
+        <div className="px-10 pt-10 pb-20  ">
+          <div className="m-auto flex max-w-[1280px]">
+            <div className="flex flex-col gap-6 max-w-[calc(100%_-_22.5rem)]">
               <div className="px-4 h-10 border-2 border-gray-900 rounded-full leading-10">
                 <Link href={"/"}>Home</Link>
                 <span> &gt; </span>
@@ -66,7 +66,7 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
                 dangerouslySetInnerHTML={{ __html: postContents.description }}
               ></div>
             </div>
-            <div className="flex flex-col items-center gap-10">
+            <div className="ml-10 w-80 flex flex-col items-center gap-10">
               <Header />
               <div className="flex flex-col gap-4">
                 {sideCardPosts

--- a/styles/postStyle.css
+++ b/styles/postStyle.css
@@ -50,20 +50,17 @@
     line-height: 175%;
   }
 
-  pre {
-    text-wrap: wrap;
+  div:has(pre) {
+    position: relative;
     margin: 2.5rem 0;
     padding: 2.5rem;
     border-radius: 1rem;
     background-color: #f1f2f4;
     border: solid 2px #232323;
+    box-sizing: border-box;
   }
 
-  div:has(code) {
-    position: relative;
-  }
-
-  div:has(code)::before {
+  div:has(pre)::before {
     content: attr(data-filename);
     position: absolute;
     top: 0.25rem;
@@ -77,6 +74,16 @@
     font-size: 12px;
     font-weight: 500;
     line-height: 1.5rem;
+  }
+  pre {
+    max-width: fit-content;
+    white-space: pre;
+    overflow-x: auto;
+  }
+
+  code {
+    display: block;
+    white-space: inherit;
   }
 
   figure {


### PR DESCRIPTION
## 概要
コードブロックの幅が画面の大きさに伴って縮んでいかない部分を作り直した

## 学び
### flexの挙動
flex指定するとwidthの挙動が若干狂いやすい。
左右2カラムある場合はどちらのカラムも動的にするよりも以下のように親にmax-widthを当てて以下の方法のどれかを取るべき。
- 左右のカラムに%指定する
or
- 比較的動きにくいサイドカラム側を定数や％指定
- 動く側の大きいカラムのmax-widthをcalcなどで指定

例えば以下の形で
```html
<div class="parent">
  <div class="child1">
    第1カラム
  </div>
  <div class="child2">
    第2カラム
  </div>
</div>
```

```css
.parent{
  max-width: 1280px
  }
.child1{
  max-width: calc(100% - {サイドカラムの値幅 + ギャップ分})
}
.child2{
  margin-left: 40px;
}
```
child1の幅は`全体幅-(child2の幅+gap)`になる