### PR TITLE
Fix carousel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,8 +24,8 @@ const Home: React.FC = async () => {
                 alt="Picture of the author"
                 className="m-auto"
               ></Image>
-              <Carousel slides={posts}></Carousel>
             </ContextualBackGround>
+            <Carousel slides={posts}></Carousel>
           </ContextualBackGround>
         </ColorProvider>
         <div className="pt-6 pb-8 px-4 h-full flex flex-col gap-12">
@@ -34,13 +34,13 @@ const Home: React.FC = async () => {
             <div className="flex flex-col items-center gap-8 flex-grow">
               <CarouselPagination />
             </div>
-            <div className="h-20 w-20 bg-gray-500 rounded-full overflow-hidden">
+            <div className="h-16 w-16 bg-gray-500 rounded-full overflow-hidden">
               <Link href={"/about"}>
                 <Image
                   src={"/my-icon.png"}
                   alt="#"
-                  width={80}
-                  height={80}
+                  width={64}
+                  height={64}
                 ></Image>
               </Link>
             </div>

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -54,7 +54,7 @@ const Carousel: React.FC<CarouselType> = (props) => {
         spaceBetween={64}
         slidesPerView={1}
         speed={800}
-        autoplay={{ delay: 3000 }}
+        autoplay={{ delay: 4000 }}
         direction="vertical"
         pagination={paginationSetting}
         modules={[Autoplay, Pagination]}

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -57,7 +57,6 @@ const Carousel: React.FC<CarouselType> = (props) => {
         autoplay={{ delay: 3000 }}
         direction="vertical"
         pagination={paginationSetting}
-        loop
         modules={[Autoplay, Pagination]}
         onSlideChange={hundleSlideChenge}
         style={{

--- a/src/components/CarouselPagination.tsx
+++ b/src/components/CarouselPagination.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const CarouselPagination: React.FC = () => {
-  return <div className="custom-pagination flex flex-col gap-8"></div>;
+  return <div className="custom-pagination flex flex-col gap-6"></div>;
 };
 
 export default CarouselPagination;

--- a/src/components/HomePostCard.tsx
+++ b/src/components/HomePostCard.tsx
@@ -31,7 +31,7 @@ const HomePostCard: React.FC<HomePostCardType> = (props) => {
           : "bg-gray-900"
       }`}
     >
-      <div className="h-full w-1/3 px-10 py-16 flex flex-col text-white-0">
+      <div className="h-full w-[calc(30%_+_4rem)] px-10 py-16 flex flex-col text-white-0">
         <div className="h-full flex-grow">
           <h2 className="text-2xl font-bold text-white">{props.title}</h2>
           <p className="mb-2 text-sm text-white">
@@ -59,7 +59,7 @@ const HomePostCard: React.FC<HomePostCardType> = (props) => {
           プロダクトへ
         </Link>
       </div>
-      <div className="w-2/3 relative">
+      <div className="relative">
         <Image
           src={props.carouselImageUrl ? props.carouselImageUrl : "/my-icon"}
           alt="hoge"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
+  safelist: ["bg-blue-600", "bg-red-600", "bg-green-600", "bg-yellow-600"],
   theme: {
     fontFamily: {
       "noto-sans-jp": ["var(--font-noto-sans-jp)", "sans-serif"],


### PR DESCRIPTION
## 概要
カルーセル周りのバグやスタイルを微修正した

## 学び
### tailwindのパージについて
tailwindでは使っていないクラス名は最終的に生成されるCSSからカットされる（パージと言う）
このパージ機能は使っていないクラス名をなくしてファイルサイズを小さくする機能だが、動的につけられるクラス名は、は、「使われている」クラス名として扱われない場合がある。

下のように**クラス名全てが指定されている場合**はパージされない
```typescript
// text-blue-500はpurgeされない
const text_blue_500 = 'text-blue-500'
document.querySelector('#sample').classList.add(text_blue_500)
```

しかし、下のように**動的にクラス名を組み立てる処理の場合**はパージされてしまう
```typescript
// text-green-500はpurgeされる
const color_level = 500
document.querySelector('#sample').classList.add(`text-green-${color_level}`)
```
[ちょっと古いtailwindの設定に関する参考記事](https://zenn.dev/ryo_kawamata/articles/purage-tailwind#purge-%E3%81%99%E3%82%8B%E9%9A%9B%E3%81%AE%E6%B3%A8%E6%84%8F%E7%82%B9)


### tailwindのsafelist機能について
上記のように動的なクラス名をつける場合はクラス名の文字列をきちんと全て指定するか、以下のようにパージしないクラス名を指定することができる。
```javascript
/** @type {import('tailwindcss').Config} */
module.exports = {
  content: [
    './pages/**/*.{html,js}',
    './components/**/*.{html,js}',
  ],
  safelist: [
    'bg-red-500',
    'text-3xl',
    'lg:text-4xl',
  ]
  // ...
}
```
ただし、この機能に頼りすぎると実質safelistだらけになって運用が崩壊するので使わなくていいなら使わない方がいい。
今回の実装ではそこまで分岐もなく、この機能を使うほどではないが足元すぐに改善するために今回は緊急で使用した。
本来なら丁寧に三項演算にクラス名を書くべきなので、余裕があればそっち方向に改善する。

[公式設定](https://tailwindcss.com/docs/content-configuration#safelisting-classes)