### PR TITLE
imageコンポーネントにobject fit coverをつけて縦横比をそのままになってほしい動きにした

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ const Home: React.FC = async () => {
     <main className="h-full">
       <div className="flex h-full">
         <ColorProvider>
-          <ContextualBackGround className="w-full h-full py-8 px-6 flex flex-col items-center gap-4">
+          <ContextualBackGround className="h-full py-8 px-6 flex flex-col items-center gap-4">
             <ContextualBackGround className="w-full" colorNumber={700}>
               <Image
                 src="/main-logo.png"
@@ -28,7 +28,7 @@ const Home: React.FC = async () => {
             <Carousel slides={posts}></Carousel>
           </ContextualBackGround>
         </ColorProvider>
-        <div className="pt-6 pb-8 px-4 h-full flex flex-col gap-12">
+        <div className="pt-6 pb-8 px-4 w-48 h-full flex flex-col gap-12">
           <Header />
           <div className="flex flex-col items-center space-y-0 flex-grow">
             <div className="flex flex-col items-center gap-8 flex-grow">

--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -74,14 +74,13 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
                     return post.postUri !== uriString.slug;
                   })
                   .map((post) => {
-                    console.log(post.carouselImage);
                     return (
                       <Link href={`/works/${post.postUri}`} key={`${post.id}`}>
                         <Card
                           id={`${post.id}`}
                           title={`${post.title}`}
                           imageUrl={`${
-                            post.carouselImage ? post.carouselImage.url : ""
+                            post.postImage ? post.postImage.url : ""
                           }`}
                           projectPeriod={`${post.projectPeriod}`}
                           tagNames={post.tags?.map(

--- a/src/components/HomePostCard.tsx
+++ b/src/components/HomePostCard.tsx
@@ -31,7 +31,7 @@ const HomePostCard: React.FC<HomePostCardType> = (props) => {
           : "bg-gray-900"
       }`}
     >
-      <div className="h-full w-[calc(30%_+_4rem)] px-10 py-16 flex flex-col text-white-0">
+      <div className="h-full w-[calc(30%_+_80px)] px-10 py-16 flex flex-col text-white-0">
         <div className="h-full flex-grow">
           <h2 className="text-2xl font-bold text-white">{props.title}</h2>
           <p className="mb-2 text-sm text-white">
@@ -59,12 +59,13 @@ const HomePostCard: React.FC<HomePostCardType> = (props) => {
           プロダクトへ
         </Link>
       </div>
-      <div className="relative">
+      <div className="flex justify-center w-full h-full overflow-hidden">
         <Image
           src={props.carouselImageUrl ? props.carouselImageUrl : "/my-icon"}
           alt="hoge"
           width={800}
           height={600}
+          className="object-cover"
         />
       </div>
     </div>


### PR DESCRIPTION
## 概要
Next Imageを縦横比そのままにcoverにした。
その他一部修正した

## 学び
### コード
```css
.hoge{
  object-fit: cover;
}
```
これを思い出した。
縦横比をそのままに、親の幅いっぱいに大きくなる。
で、縦横比が狂ってはみ出た部分はカットされる。

### 参考
[MDN](https://developer.mozilla.org/ja/docs/Web/CSS/object-fit)