### PR TITLE
幅100%に修正追加

### DIFF
--- a/src/components/HomePostCard.tsx
+++ b/src/components/HomePostCard.tsx
@@ -65,7 +65,7 @@ const HomePostCard: React.FC<HomePostCardType> = (props) => {
           alt="hoge"
           width={800}
           height={600}
-          className="object-cover"
+          className="object-cover w-full"
         />
       </div>
     </div>


### PR DESCRIPTION
## 概要
画像の幅を100%にする

## 学び
### divで囲ったimgの最終的なスタイルの付け方

```html
<div>
  <img class="inner-image"/>
</div>
```
このhtml（jsx）の場合以下のCSSを当てるのが正解
```css
.inner-image{
  width: 100%;
  object-fit: cover;
}
```
imgは以下の挙動をする
- 縦横比はそのままに親の幅いっぱいに広がる
- 親の縦横比が画像の縦横比と違う場合、上下の高さ側ではみ出した部分が消える
- 画像は上下左右で中央配置になる

## 参考
[MDN](https://developer.mozilla.org/ja/docs/Web/CSS/object-fit)
[ちょっとした参考](https://webdesignday.jp/programing/object-fit/)