### PR TITLE
ついにできた

### DIFF
--- a/libs/dataFetch.ts
+++ b/libs/dataFetch.ts
@@ -1,6 +1,6 @@
 import { client } from "./client";
 //import { Post,Tag } from "../types/postType";　一旦型は後回し
-import { TagType } from "../types/postType";
+import { PostType, TagType } from "../types/postType";
 
 ////////////local type////////////
 
@@ -72,7 +72,7 @@ export async function getPostBySlug(slug: string) {
   return data;
 }
 
-export async function getAllPosts() {
+export async function getAllPosts(): Promise<PostType[]> {
   const data = await client.getAllContents({
     endpoint: "posts",
   });
@@ -115,7 +115,7 @@ export async function getPostsByTagName(tagNames: string[]) {
 
 ////////////get tag function////////////
 
-export async function getAllTags() {
+export async function getAllTags(): Promise<TagType[]> {
   const data = await client.getAllContents({
     endpoint: "tags",
   });

--- a/src/app/works/[slug]/page.tsx
+++ b/src/app/works/[slug]/page.tsx
@@ -73,6 +73,9 @@ const PostPage = async ({ params }: paramsType<returnParamsValueType>) => {
                   .filter((post) => {
                     return post.postUri !== uriString.slug;
                   })
+                  .sort((a, b) => {
+                    return a.order - b.order;
+                  })
                   .map((post) => {
                     return (
                       <Link href={`/works/${post.postUri}`} key={`${post.id}`}>

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Image from "next/image";
-import FilterTag from "../../components/FilterTag";
 import FilterTags from "../../components/FilterTags";
 import WorksList from "../../components/WorksList";
 import Header from "../../components/Header";

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -4,14 +4,15 @@ import React, { useEffect } from "react";
 import { useColorContext } from "../context/ColorContext";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay, Pagination } from "swiper/modules";
-import { PaginationOptions } from "swiper/types";
+import { PaginationOptions, Swiper as SwiperType } from "swiper/types";
+import HomePostCard from "./HomePostCard";
+import { PostType } from "../../types/postType";
 import "swiper/css";
 import "swiper/css/pagination";
 import "../../styles/customPagination.css";
-import HomePostCard from "./HomePostCard";
 
 type CarouselType = {
-  slides: any[];
+  slides: PostType[];
 };
 
 const Carousel: React.FC<CarouselType> = (props) => {
@@ -31,7 +32,7 @@ const Carousel: React.FC<CarouselType> = (props) => {
   });
 
   //handler
-  const hundleSlideChenge = (swiper: any) => {
+  const hundleSlideChenge = (swiper: SwiperType) => {
     const activeSlide = sortedSlides[swiper.activeIndex];
     if (activeSlide) {
       setOrderForColor(activeSlide.order);

--- a/src/components/ContextualBackGroud.tsx
+++ b/src/components/ContextualBackGroud.tsx
@@ -13,8 +13,6 @@ const ContextualBackGround: React.FC<PropsType> = (props) => {
   const { orderForColor } = useColorContext();
   const order = orderForColor;
 
-  //console.log(order);
-
   const bgColor =
     order % 4 === 1
       ? `bg-blue-${props.colorNumber ? props.colorNumber : "600"}`

--- a/src/components/FilterTag.tsx
+++ b/src/components/FilterTag.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import { useFilterIdContext } from "../context/FilterContext";
 import { TagType } from "../../types/postType";
 

--- a/src/components/FilterTags.tsx
+++ b/src/components/FilterTags.tsx
@@ -11,7 +11,6 @@ type PropType = {
 
 const FilterTags: React.FC<PropType> = (props) => {
   const { filterId } = useFilterIdContext();
-  console.log(filterId);
 
   return (
     <>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import { useFilterIdContext } from "../context/FilterContext";
 import { TagType } from "../../types/postType";
 
 type PickTagType = Pick<TagType, "id" | "tagName">;

--- a/src/components/WorksList.tsx
+++ b/src/components/WorksList.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React from "react";
 import Card from "../components/Card";
 import Link from "next/link";
-import { TagType } from "../../types/postType";
+import { PostType, TagType } from "../../types/postType";
 import { useFilterIdContext } from "../context/FilterContext";
 
 type PropsType = {
-  posts: any[];
+  posts: PostType[];
 };
 
 const WorksList: React.FC<PropsType> = (props) => {
@@ -19,7 +19,7 @@ const WorksList: React.FC<PropsType> = (props) => {
 
   const displayedPosts = filterId
     ? sortedPosts.filter((post) => {
-        return post.tags.some((tag: TagType) => {
+        return post.tags?.some((tag: TagType) => {
           return filterId === tag.id;
         });
       })

--- a/types/postType.ts
+++ b/types/postType.ts
@@ -13,6 +13,7 @@ export type MicroCmsImageType = {
 };
 
 export type PostType = MicroCmsApiReturnType & {
+  order: number;
   title: string;
   postUri: string;
   postImage?: MicroCmsImageType;


### PR DESCRIPTION
## 概要
ビルドのための以下の必要なことをおこなった
- 使っていない関数やコンポーネントの削除
- any型の削除
- PostTypeの拡張
- envファイルからdevelopを削除
- その他細かい処理を手直し

## 学び
### Swiperの型
以下のファイルからSwiperの型が呼び出せる。Swiperを使うコンポーネント内で呼び出せる引数としてのswiperを受けるときに使用する。今回はハンドラ関数で使用した。この型を当てるとswiperオブジェクトから提供される要素のインテリセンスが効くので、もっと早くに当てればよかった。
```typescript
import { Swiper as SwiperType } from "swiper/types";

const hundleSlideChenge = (swiper: SwiperType) => {
    const activeSlide = sortedSlides[swiper.activeIndex];
    if (activeSlide) {
      setOrderForColor(activeSlide.order);
    }
  };
```
ただし、普通のSwiperのコンポーネントと名前が競合するのでasでエイリアスを変える
```typescript
//普通のSwiperのコンポーネントにSwiperがある
import { Swiper, SwiperSlide } from "swiper/react";
```

### envファイルの設定
envファイルの設定を忘れかけた
#13 のPRにenvファイルに関しては書いた

### fetch関数の返り値の型指定
以下のようにfetch関数の時点で返却値の型を当ててしまった方がよかった。
これを当てていればそのあと呼び出して取得した配列にもきちんとインテリセンスが効いたので。
データの受け渡し周りは早めに型を決めてつけてしまった方がコードを書く上でも楽だった。
```typescript
export async function getAllPosts(): Promise<PostType[]> {
  const data = await client.getAllContents({
    endpoint: "posts",
  });

  return data;
}
```

### 型の保証は親側か子側か
今回は子側のpropsの型として保証することにした。
propsを受け取る側＝描画される最後の砦なので、子供側がカチッとしてれば変な値を放り込まれることもないはずなので。

```typescript
"use client";

import React from "react";
import { PostType } from "../../types/postType";

type CarouselType = {
  slides: PostType[];
};

const Carousel: React.FC<CarouselType> = (props) => {
  return (
    <div></div>
  );
};

export default Carousel;
```



