### PR TITLE
ソートとフィルターの順番を直して、フィルターを先にした

### DIFF
--- a/src/components/WorksList.tsx
+++ b/src/components/WorksList.tsx
@@ -11,23 +11,25 @@ type PropsType = {
 };
 
 const WorksList: React.FC<PropsType> = (props) => {
-  const sortedPosts = props.posts.sort((a, b) => {
-    return a.order - b.order;
-  });
-
   const { filterId } = useFilterIdContext();
 
   const displayedPosts = filterId
-    ? sortedPosts.filter((post) => {
-        return post.tags?.some((tag: TagType) => {
-          return filterId === tag.id;
-        });
-      })
-    : sortedPosts;
+    ? props.posts
+        .filter((post) => {
+          return post.tags?.some((tag: TagType) => {
+            return filterId === tag.id;
+          });
+        })
+        .sort((a, b) => {
+          return a.order - b.order;
+        })
+    : props.posts.sort((a, b) => {
+        return a.order - b.order;
+      });
 
   return (
     <>
-      {displayedPosts.map((post) => {
+      {displayedPosts?.map((post) => {
         const postTags = post.tags?.map((tag: TagType) => {
           return tag.tagName;
         });


### PR DESCRIPTION
## 概要
これまでworksページはソートしてからフィルターしていたが、フィルターしてからソートに変更

## 学び
一般的にソートはデータが多いほど処理が重くなるので、フィルターで先に必要な要素までデータを間引いてしまってからソートをする方が良いため。